### PR TITLE
Encrypt the GitLog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,11 @@ data-encoding = "2.1.1"
 time = "0.1.39"
 tempfile = "3.0.1"
 assert_matches = "1.2.0"
-sled = "0.15.17"
 
-[dev-dependencies]
-quickcheck = "0.6.2"
-
-# [dependencies.sled]
-# path = "../sled/crates/sled"
+[dependencies.sled]
+# version = "0.15.17"
+features = ["zstd"]
+path = "../sled/crates/sled"
 
 [dependencies.crdts]
 path = "../rust-crdt"
@@ -28,3 +26,7 @@ path = "../rust-crdt"
 [dependencies.bincode]
 version = "1.0.1"
 features = ["i128"]
+
+
+[dev-dependencies]
+quickcheck = "0.6.2"

--- a/src/git_log.rs
+++ b/src/git_log.rs
@@ -16,7 +16,7 @@ use crdts::{CmRDT, Actor};
 use log::{TaggedOp, LogReplicable};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Auth {
+pub struct GitRemoteAuth {
     user: String,
     pass: String
 }
@@ -27,7 +27,7 @@ pub struct Log<A: Actor, C: Debug + CmRDT>
     actor: A,
     name: String,
     url: String,
-    auth: Option<Auth>,
+    auth: Option<GitRemoteAuth>,
     repo: git2::Repository,
     phantom_crdt: PhantomData<C>
 }
@@ -324,7 +324,7 @@ impl<A: Actor, C: Debug + CmRDT> Log<A, C>
             actor: actor,
             name: name,
             url: url,
-            auth: Some(Auth { user, pass }),
+            auth: Some(GitRemoteAuth { user, pass }),
             repo: repo,
             phantom_crdt: PhantomData
         }
@@ -345,7 +345,7 @@ impl<A: Actor, C: Debug + CmRDT> Log<A, C>
         let mut cbs = git2::RemoteCallbacks::new();
         cbs.credentials(move |_, _, _| {
             match self.auth {
-                Some(Auth {ref user, ref pass} ) =>
+                Some(GitRemoteAuth {ref user, ref pass} ) =>
                     git2::Cred::userpass_plaintext(user, pass),
                 None => {
                     panic!("This should never be called!");


### PR DESCRIPTION
Somethings to consider:
- should encryption be handled by the log implementation itself? or should it be done by hermitdb core?