### PR TITLE
git remote for rust-crdt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ quickcheck = "0.6.2"
 # path = "../sled/crates/sled"
 
 [dependencies.crdts]
-path = "../rust-crdt"
+git = "https://github.com/davidrusu/rust-crdt"
+branch = "op-replication"
 
 [dependencies.bincode]
 version = "1.0.1"


### PR DESCRIPTION
This requires a little more work if you are hacking on crdts to support
hermitdb, but it allows an easier clone/build for hermitdb.